### PR TITLE
feat!: Rename artifact to uxcam-kmp (v2.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2026-01-14
+
+### Breaking Changes
+
+- **Artifact renamed**: `dev.onexeor:uxcam-kmp-shared` → `dev.onexeor:uxcam-kmp`
+
+  Update your dependencies:
+  ```kotlin
+  // Before
+  implementation("dev.onexeor:uxcam-kmp-shared:<version>")
+
+  // After
+  implementation("dev.onexeor:uxcam-kmp:<version>")
+  ```
+
 ## [1.3.0] - 2026-01-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Add the dependency to your shared module's `build.gradle.kts`:
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("dev.onexeor:uxcam-kmp-shared:<version>")
+            implementation("dev.onexeor:uxcam-kmp:<version>")
         }
     }
 }
@@ -65,7 +65,7 @@ Add the dependency to your module's `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("dev.onexeor:uxcam-kmp-shared:<version>")
+    implementation("dev.onexeor:uxcam-kmp:<version>")
 }
 ```
 
@@ -74,7 +74,7 @@ dependencies {
 Add to your `Podfile`:
 
 ```ruby
-pod 'uxcam-kmp-shared', :git => 'https://github.com/OneXeor/UXCam-KMP.git'
+pod 'uxcam-kmp', :git => 'https://github.com/OneXeor/UXCam-KMP.git'
 ```
 
 Then run:
@@ -215,13 +215,13 @@ UXCam.addScreenNamesToIgnore(listOf("LoginScreen", "SettingsScreen"))
 
 ```bash
 # Build the library
-./gradlew :uxcam-kmp-shared:build
+./gradlew :uxcam-kmp:build
 
 # Run tests
-./gradlew :uxcam-kmp-shared:allTests
+./gradlew :uxcam-kmp:allTests
 
 # Generate iOS framework
-./gradlew :uxcam-kmp-shared:generateDummyFramework
+./gradlew :uxcam-kmp:generateDummyFramework
 ```
 
 ## Roadmap

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,11 +13,11 @@ kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 
 # Library Version
-VERSION_NAME=1.3.0
+VERSION_NAME=2.0.0
 
 # Maven Central Publishing (Sonatype Central Portal)
 GROUP=dev.onexeor
-POM_ARTIFACT_ID=uxcam-kmp-shared
+POM_ARTIFACT_ID=uxcam-kmp
 POM_NAME=UXCam KMP
 POM_DESCRIPTION=Kotlin Multiplatform wrapper for UXCam SDK
 POM_URL=https://github.com/OneXeor/UXCam-KMP


### PR DESCRIPTION
## Summary

**BREAKING CHANGE**: Rename Maven artifact for cleaner dependency declaration.

## Breaking Change

Artifact ID changed:
- **Before**: `dev.onexeor:uxcam-kmp-shared`
- **After**: `dev.onexeor:uxcam-kmp`

### Migration

Update your dependencies:

```kotlin
// Before
implementation("dev.onexeor:uxcam-kmp-shared:<version>")

// After  
implementation("dev.onexeor:uxcam-kmp:2.0.0")
```

## Rationale

- Cleaner artifact name without redundant "-shared" suffix
- Follows conventions of popular KMP libraries (Ktor, Koin, Napier)
- "-kmp" suffix already indicates Kotlin Multiplatform

## Test plan

- [ ] Build passes on all platforms
- [ ] Artifact publishes with new name to Maven Central